### PR TITLE
attempt to add unary op support

### DIFF
--- a/vml/detail/swizzler.h
+++ b/vml/detail/swizzler.h
@@ -36,6 +36,7 @@ struct swizzler
 	//TODO: constrain the assignment only when indices are different
 
 	using self_type = swizzler;
+	using other_type = vector_type;
 	using scalar_type = T;
 #define Is indices
 #define HAS_UNARY_MUL

--- a/vml/detail/swizzler.h
+++ b/vml/detail/swizzler.h
@@ -35,7 +35,18 @@ struct swizzler
 
 	//TODO: constrain the assignment only when indices are different
 
-	//TODO: impl unary ops
+	using self_type = swizzler;
+	using scalar_type = T;
+#define Is indices
+#define HAS_UNARY_MUL
+#define OMIT_NEG_OP
+#include "unary_ops.h"
+
+	vector_type operator -() const
+	{
+		return vector_type((-data[indices])...);
+	}
+#undef OMIT_NEG_OP
 
 private:
 	template<typename... Indices>

--- a/vml/detail/unary_ops.h
+++ b/vml/detail/unary_ops.h
@@ -1,4 +1,4 @@
-// must define `self_type`
+// must define `self_type` and `other_type`
 // must define `Is` as the param pack expansion of the indices
 
 #define DEF_OP_UNARY_SCALAR(op)				\
@@ -14,7 +14,7 @@ DEF_OP_UNARY_SCALAR(*=)
 DEF_OP_UNARY_SCALAR(/=)
 
 #define DEF_OP_UNARY_VECTOR(op)				\
-	self_type& operator op(const self_type &v) \
+	self_type& operator op(const other_type &v) \
 	{										\
 		((data[Is] op v.data[Is]), ...);	\
 		return *this;						\

--- a/vml/detail/unary_ops.h
+++ b/vml/detail/unary_ops.h
@@ -28,10 +28,12 @@ DEF_OP_UNARY_VECTOR(*=)
 #endif
 DEF_OP_UNARY_VECTOR(/=)
 
+#ifndef OMIT_NEG_OP
 self_type operator -() const
 {
 	return self_type((-data[Is])...);
 }
+#endif // !OMIT_NEG_OP
 
 //TODO: add  ==, !=
 

--- a/vml/matrix.h
+++ b/vml/matrix.h
@@ -62,6 +62,7 @@ struct matrix<scalar_type, vector_type, indices_pack<Columns...>, indices_pack<R
 	}
 
 	using self_type = matrix;
+	using other_type = self_type;
 #define Is Rows
 #include "detail/unary_ops.h"
 

--- a/vml/vector.h
+++ b/vml/vector.h
@@ -84,6 +84,7 @@ struct _MSC_FIX_EBO vector :
 	}
 
 	using self_type = vector_type;
+	using other_type = self_type;
 #define Is Ns
 #define HAS_UNARY_MUL
 #include "detail/unary_ops.h"


### PR DESCRIPTION
Adding unary ops to swizzler to support things like `-v.xy` and `v.xy += 1.0`

NOTE: `v.xy += v.xx` won't work